### PR TITLE
Camera connection - use substream instead of mainstream

### DIFF
--- a/main.py
+++ b/main.py
@@ -548,7 +548,7 @@ def receive(producer_q):
     cam_ip = os.environ['CAM_IP']
     cam_pw = os.environ['CAM_PW']
     connect_str = "rtsp://admin:" + cam_pw + "@" + cam_ip
-    connect_str2 = connect_str + ":554" + "//h264Preview_01_main" # this might be different depending on camera used
+    connect_str2 = connect_str + ":554" + "//h264Preview_01_sub" # this might be different depending on camera used
 
     os.environ['OPENCV_FFMPEG_CAPTURE_OPTIONS'] = 'rtsp_transport;tcp' # Use tcp instead of udp if stream is unstable
     c = cv2.VideoCapture(connect_str)


### PR DESCRIPTION
This PR switches the sample connection string to use [substream](https://help.lorextechnology.com/link/portal/57356/57366/Article/1392/Configuration-Mainstream-vs-substream), instead of the mainstream. I recently discovered that this exists, and upon testing, increases stability of the live feed processing service significantly (haven't seen it go down yet). 

There are some known issues regarding live-mode's stability, where after a period of time, the service will crash with errors similar to what's [described here](https://github.com/calebolson123/BabySleepCoach/issues/8).

Using substream instead of mainstream reduces the bandwidth of the stream, increasing stability, while maintaining clear enough images for the core computer vision logic to recognize baby features over time.

An [upcoming PR](https://github.com/calebolson123/BabySleepCoach/pull/6) largely overhauling the design replaces this line, and a note about the difference between `mainstream` and `substream` ideally would be preserved in (or after) that PR so that users know about the now preferred substream channel.