### PR TITLE
Added video streams and settings.yml 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ build
 !*.ipynb
 !requirements.txt
 !.env_sample
+!settings.yml

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ Alternatively you can `touch .env` and then copy and paste the contents of `.env
 
 The sleep data is written to `sleep_logs.csv`. I primed this file with a few rows as an example. Feel free to remove these and start from scratch.
 
+It is possible to watch the live stream of the camera (and debug view) at: http://URL_OF_BACKEND:PORT_OF_BACKEND/videostream and http://URL_OF_BACKEND:PORT_OF_BACKEND/videostream_debug
+
+To reload the settings from the yml file, open http://URL_OF_BACKEND:PORT_OF_BACKEND/reload_settings
+
 ### Part 2: The Web App
 
 This one is more straight forward. Just make sure you have [`yarn`](https://yarnpkg.com/getting-started/install).

--- a/helpers.py
+++ b/helpers.py
@@ -133,7 +133,7 @@ def check_mouth_open(landmarks):
 
 
 # Resizes a image and maintains aspect ratio
-def maintain_aspect_ratio_resize(self, image, width=None, height=None, inter=cv2.INTER_AREA):
+def maintain_aspect_ratio_resize(image, width=None, height=None, inter=cv2.INTER_AREA):
     # Grab the image size and initialize dimensions
     dim = None
     (h, w) = image.shape[:2]
@@ -157,7 +157,7 @@ def maintain_aspect_ratio_resize(self, image, width=None, height=None, inter=cv2
     return cv2.resize(image, dim, interpolation=inter)
 
 
-def gamma_correction(self, og, gamma):
+def gamma_correction(og, gamma):
     invGamma = 1 / gamma
     table = [((i / 255) ** invGamma) * 255 for i in range(256)]
     table = np.array(table, np.uint8)

--- a/main.py
+++ b/main.py
@@ -73,7 +73,7 @@ class SleepyBaby():
         self.ser = None # serial connection to arduino for controlling demon owl
 
         self.current_image = np.zeros((settings.get('image_height_scaled', 540), settings.get('image_width_scaled', 960),3), np.uint8) # black image for init
-        self.debug_image = np.zeros((settings.get('image_height_scaled', 540), settings.get('image_width_scaled', 960),3), np.uint8) # black image for init
+        self.debug_image = np.zeros((settings.get('image_height_scaled', 540), settings.get('image_width_scaled', 960),3), np.uint8) # black image for init 
 
         # If demon owl mode, setup connection to arduino and cast service for playing audio
         if os.getenv("OWL", 'False').lower() in ('true', '1'):
@@ -485,6 +485,13 @@ class SleepyBaby():
 
                 img_to_process = img[y:y+h, x:x+w]
                 self.current_image = img.copy()
+                if self.is_awake:
+                    text_awake = "Awake"
+                else:
+                    text_awake = "Asleep"
+                height, width = self.current_image.shape[:2]
+                cv2.putText(self.current_image, text_awake,(20, (int)(height-height*0.1)), 2, 1, (255,0,0), 2, 2)   
+                
 
                 debug_img = self.frame_logic(img_to_process)
 

--- a/main.py
+++ b/main.py
@@ -481,7 +481,7 @@ class SleepyBaby():
                 w = settings.get('baby_roi_w', 800)
 
                 if img.shape[0] > 1080 and img.shape[1] > 1920: # max res 1080p
-                    img = maintain_aspect_ratio_resize(width=self.frame_dim[0], height=self.frame_dim[1])
+                    img = maintain_aspect_ratio_resize(img, width=self.frame_dim[0], height=self.frame_dim[1])
 
                 img_to_process = img[y:y+h, x:x+w]
                 self.current_image = img.copy()

--- a/main.py
+++ b/main.py
@@ -481,7 +481,7 @@ class SleepyBaby():
                 w = settings.get('baby_roi_w', 800)
 
                 if img.shape[0] > 1080 and img.shape[1] > 1920: # max res 1080p
-                    img = maintain_aspect_ratio_resize(self=self, width=self.frame_dim[0], height=self.frame_dim[1])
+                    img = maintain_aspect_ratio_resize(width=self.frame_dim[0], height=self.frame_dim[1])
 
                 img_to_process = img[y:y+h, x:x+w]
                 self.current_image = img.copy()
@@ -502,7 +502,7 @@ class SleepyBaby():
                     try:
                         cv2.rectangle(img=img, pt1=(x, y), pt2=(x+w, y+h), color=[153,50,204], thickness=2)
                         tmp = img[y:y+h, x:x+w]
-                        img = gamma_correction(self, img, .4)
+                        img = gamma_correction(img, .4)
 
                         for face_landmarks in self.multi_face_landmarks:
 
@@ -531,7 +531,7 @@ class SleepyBaby():
 
                         img = cv2.resize(img, (settings.get('image_width_scaled', 960), settings.get('image_height_scaled', 540)))
                         self.debug_image = img.copy()
-                        cv2.imshow('baby', maintain_aspect_ratio_resize(self, img, width=self.frame_dim[0], height=self.frame_dim[1]))
+                        cv2.imshow('baby', maintain_aspect_ratio_resize(img, width=self.frame_dim[0], height=self.frame_dim[1]))
 
                         if cv2.waitKey(1) & 0xFF == ord('q'):
                             break

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ from dotenv import load_dotenv
 # from cast_service import CastSoundService
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 from helpers import check_eyes_open, set_hatch, check_mouth_open, maintain_aspect_ratio_resize, gamma_correction
-
+import yaml
 load_dotenv()
 
 # Uncomment if want phone notifications during daytime wakings.
@@ -32,6 +32,12 @@ logging.basicConfig(filename=logfile,
 # This is to get around an underlying bug, described at end of this file.
 frame_q = deque(maxlen=20)
 
+def loadSettings():
+    # Load the settings
+    with open('./settings.yml', 'r') as file:
+        return yaml.safe_load(file) or {} # if file is empty, create empty dict
+
+settings = loadSettings()
 class SleepyBaby():
 
     # TODO: break up this class, so big ew
@@ -65,6 +71,9 @@ class SleepyBaby():
         self.multi_face_landmarks = []
         self.is_awake = False
         self.ser = None # serial connection to arduino for controlling demon owl
+
+        self.current_image = np.zeros((settings.get('image_height_scaled', 540), settings.get('image_width_scaled', 960),3), np.uint8) # black image for init
+        self.debug_image = np.zeros((settings.get('image_height_scaled', 540), settings.get('image_width_scaled', 960),3), np.uint8) # black image for init
 
         # If demon owl mode, setup connection to arduino and cast service for playing audio
         if os.getenv("OWL", 'False').lower() in ('true', '1'):
@@ -383,10 +392,10 @@ class SleepyBaby():
 
                     if all(e is not None for e in [frame, img]):
                         # bounds to actual run models/analysis on...no need to look for babies outside of the crib
-                        x = 800
-                        y = 250
-                        h = 650
-                        w = 600
+                        x = settings.get('baby_roi_x', 700)
+                        y = settings.get('baby_roi_y', 125)
+                        h = settings.get('baby_roi_h', 1000)
+                        w = settings.get('baby_roi_w', 800)
 
                         if img.shape[0] > 1080 and img.shape[1] > 1920: # max res 1080p
                             img = maintain_aspect_ratio_resize(img, width=self.frame_dim[0], height=self.frame_dim[1])
@@ -446,7 +455,7 @@ class SleepyBaby():
                             img[y:y+h, x:x+w] = tmp
 
                             try:
-                                img = cv2.resize(img, (960, 540))
+                                img = cv2.resize(img, (settings.get('image_width_scaled', 960), settings.get('image_height_scaled', 540)))
                                 self.debug_image = img
                                 cv2.imshow('baby', img)
                                 if cv2.waitKey(1) & 0xFF == ord('q'):
@@ -466,15 +475,16 @@ class SleepyBaby():
                     continue
 
                 # bounds to actual run models/analysis on...no need to look for babies outside of the crib
-                x = 700
-                y = 125
-                h = 1000
-                w = 800
+                x = settings.get('baby_roi_x', 700)
+                y = settings.get('baby_roi_y', 125)
+                h = settings.get('baby_roi_h', 1000)
+                w = settings.get('baby_roi_w', 800)
 
                 if img.shape[0] > 1080 and img.shape[1] > 1920: # max res 1080p
-                    img = maintain_aspect_ratio_resize(img, width=self.frame_dim[0], height=self.frame_dim[1])
+                    img = maintain_aspect_ratio_resize(self=self, width=self.frame_dim[0], height=self.frame_dim[1])
 
                 img_to_process = img[y:y+h, x:x+w]
+                self.current_image = img.copy()
 
                 debug_img = self.frame_logic(img_to_process)
 
@@ -485,7 +495,7 @@ class SleepyBaby():
                     try:
                         cv2.rectangle(img=img, pt1=(x, y), pt2=(x+w, y+h), color=[153,50,204], thickness=2)
                         tmp = img[y:y+h, x:x+w]
-                        img = gamma_correction(img, .4)
+                        img = gamma_correction(self, img, .4)
 
                         for face_landmarks in self.multi_face_landmarks:
 
@@ -512,9 +522,9 @@ class SleepyBaby():
 
                         img[y:y+h, x:x+w] = tmp
 
-                        img = cv2.resize(img, (960, 540))
-                        self.current_image = img
-                        cv2.imshow('baby', maintain_aspect_ratio_resize(img, width=self.frame_dim[0], height=self.frame_dim[1]))
+                        img = cv2.resize(img, (settings.get('image_width_scaled', 960), settings.get('image_height_scaled', 540)))
+                        self.debug_image = img.copy()
+                        cv2.imshow('baby', maintain_aspect_ratio_resize(self, img, width=self.frame_dim[0], height=self.frame_dim[1]))
 
                         if cv2.waitKey(1) & 0xFF == ord('q'):
                             break
@@ -541,20 +551,37 @@ class CORSRequestHandler(SimpleHTTPRequestHandler):
     def do_GET(self):
         print('connection from:', self.address_string())
 
-        if self.path == '/videostream':
-            print('mjpg')
+        if self.path == '/videostream' or self.path == '/videostream_debug':
+            print('videostream')
             self.send_response(200)
             self.send_header('Content-type', 'multipart/x-mixed-replace; boundary=--jpgboundary')
             self.end_headers()
 
             while True:
-                ret, jpg = cv2.imencode('.jpg', sleepy_baby.current_image)
-                self.wfile.write("--jpgboundary")
-                self.send_header('Content-type', 'image/jpeg')
-                self.send_header('Content-length', str(jpg.size))
-                self.end_headers()
-                self.wfile.write(jpg.tostring())
-                time.sleep(0.05)
+                try:
+                    if self.path == '/videostream_debug':
+                        image_to_show = sleepy_baby.debug_image
+                    else:
+                        image_to_show = sleepy_baby.current_image
+                    ret, jpg = cv2.imencode('.jpg', image_to_show)
+                    self.send_header('Content-type','multipart/x-mixed-replace; boundary=--jpgboundary')
+                    self.send_header('Content-length', str(jpg.size))
+                    self.end_headers()
+                    self.wfile.write(jpg.tobytes())
+                    time.sleep(0.05)
+                except Exception as e:
+                    print("Videostream error: ", e)
+                    break
+
+        elif self.path == '/reload_settings':
+            global settings
+            settings = loadSettings()
+            self.send_response(200)
+            self.send_header('Content-type', 'text/html')
+            self.end_headers()
+            self.wfile.write('<html><head></head><body><h1>Reloaded</h1></body></html>'.encode("utf-8"))
+        else:
+            return SimpleHTTPRequestHandler.do_GET(self)
 
 def start_server():
     httpd = HTTPServer(('0.0.0.0', 8000), CORSRequestHandler)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ python-dotenv==0.21.1
 scikit_learn==1.2.1
 statsmodels==0.13.5
 tbats==1.1.2
+PyYAML==6.0

--- a/settings.yml
+++ b/settings.yml
@@ -1,0 +1,6 @@
+image_height_scaled: 540
+image_width_scaled: 960
+baby_roi_x: 700
+baby_roi_y: 125
+baby_roi_h: 1000
+baby_roi_w: 800


### PR DESCRIPTION
I added two video streams (live stream with text awake/asleep and the debug stream) to the backend. I also added a yml file for the settings of the ROI. For the reload of the settings file I added a http endpoint "reload_settings".

In the future the live stream could be added to the frontend.