### PR TITLE
Replace both CAM_IP and CAM_PW by more generic CAM_URL

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -1,5 +1,4 @@
-CAM_IP=<ip_of_your_camera> # ip of the baby camera
-CAM_PW=<password> # password for baby camera
+CAM_URL=<url_of_your_camera> # full url of the baby camera
 APP_DIR=/usr/app/babysleepcoach # location of app root, primarily used for docker
 DEBUG=False
 OWL=False # lol

--- a/README.md
+++ b/README.md
@@ -30,9 +30,7 @@ Copy the .env_sample template into .env
 
 ### Configure .env file:
 
-`CAM_IP` IP of your camera
-
-`CAM_PW` pw for accessing your camera
+`CAM_URL` URL of your camera. Likely `rtsp://admin:password@192.168.CAMERA_IP:554/h264Preview_01_sub` or `/dev/video0` for a webcam
 
 `PORT` Port for accessing web app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,4 +15,6 @@ services:
         # You need to update this to absolute path of this dir on your machine
         source: C:\Users\caleb\projects\github-sleepy-baby\BabySleepCoach\
         target: "${APP_DIR}"
-    container_name: baby-sleep-coach
+    # To use a webcam, uncomment these lines
+    # devices:
+    #   - /dev/video0

--- a/main.py
+++ b/main.py
@@ -995,13 +995,11 @@ def server(creepy_baby_model, frame_q, debug_frame_q, cropped_raw_frame_q, sleep
 
 def receive(producer_q):
     print("Start receiving frames.")
-    cam_ip = os.environ['CAM_IP']
-    cam_pw = os.environ['CAM_PW']
-    connect_str = "rtsp://admin:" + cam_pw + "@" + cam_ip
-    connect_str2 = connect_str + ":554" + "//h264Preview_01_sub" # this might be different depending on camera used
+    cam_url = os.environ['CAM_URL']
+    print(f"Connecting to camera at: {cam_url}")
 
     os.environ['OPENCV_FFMPEG_CAPTURE_OPTIONS'] = 'rtsp_transport;tcp' # Use tcp instead of udp if stream is unstable
-    c = cv2.VideoCapture(connect_str)
+    c = cv2.VideoCapture(cam_url)
 
     next_frame = 0
     fps = 30


### PR DESCRIPTION
This allows to use RTSP cameras with other path or username.
But because we use OpenCV, one can also use a webcam like /dev/video0
But the device /dev/video0 needs to be added to docker-compose.yml