### PR TITLE
Fix docker startup issues

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -1,9 +1,9 @@
-CAM_URL=<url_of_your_camera> # full url of the baby camera
+CAM_URL=rtsp://username:password@<cam_ip>:554/h264Preview_01_sub # full url of the baby camera
 APP_DIR=/usr/app/babysleepcoach # location of app root, primarily used for docker
 DEBUG=False
 OWL=False # lol
 VIDEO_PATH=/usr/app/babysleepcoach/video # for debugging & testing
 HATCH_IP=192.168.HATCH.IP # optional
-REACT_APP_BACKEND_IP=192.168.0.206:8001 # ip of flask server. This is the ip of "this" machine running the system
-REACT_APP_RESOURCE_SERVER_IP=192.168.0.206:8000 # ip of resource server (TODO: align to 1 server). This is the ip of "this" machine running the system
+REACT_APP_BACKEND_IP=localhost:8001 # ip of flask server. Probably just localhost
+REACT_APP_RESOURCE_SERVER_IP=localhost:8000 # ip of resource server
 PORT=80 # port web app serves assets from

--- a/README.md
+++ b/README.md
@@ -42,9 +42,5 @@ Copy the .env_sample template into .env
 
 `VIDEO_PATH` (optional) use to set path to recorded footage for debugging
 
-### Update docker-compose
-
-Update the path in `docker-compose.yml` to be the root of this project on your machine.
-
 ### Run it
 `docker compose up`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,10 +11,8 @@ services:
     env_file:
       - .env
     volumes:
-      - type: bind
-        # You need to update this to absolute path of this dir on your machine
-        source: C:\Users\caleb\projects\github-sleepy-baby\BabySleepCoach\
-        target: "${APP_DIR}"
+      - .:/usr/app/babysleepcoach
+      - /usr/app/babysleepcoach/webapp/node_modules
     # To use a webcam, uncomment these lines
     # devices:
     #   - /dev/video0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mediapipe==0.9.1.0
+mediapipe==0.10.3
 pyhatchbabyrest==2.1.0
 pyserial==3.5
 matplotlib==3.7.0


### PR DESCRIPTION
This PR brings in fixed for common issues reported when starting the app the first time. Changes include:

- Ignoring node_modules when mounting volumes
- Upgrading mediapipe to a version found in recent version of docker base image used (node:slim)
- Simplified server IPs to default to localhost. I also included an example of what my CAM_URL looks like