### PR TITLE
Docker Pip build speed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:slim
 WORKDIR /usr/app/babysleepcoach
 EXPOSE 80
 
-#Copy all files in the container
+#Copy the pip build files in first
 COPY ./requirements.txt .
 
 # Install required packages
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install python3-pip libgl1 libglib2.0-0  -y
 RUN pip3 install --upgrade pip
 RUN pip3 install -r requirements.txt
 
-# Copy in the rest of the file
+# Copy in the rest of the files
 COPY . .
 
 RUN cd webapp && yarn install && cd ..

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,16 @@ WORKDIR /usr/app/babysleepcoach
 EXPOSE 80
 
 #Copy all files in the container
-COPY . .
+COPY ./requirements.txt .
 
 # Install required packages
 ENV PIP_BREAK_SYSTEM_PACKAGES 1
 RUN apt-get update && apt-get install python3-pip libgl1 libglib2.0-0  -y
 RUN pip3 install --upgrade pip
 RUN pip3 install -r requirements.txt
+
+# Copy in the rest of the file
+COPY . .
 
 RUN cd webapp && yarn install && cd ..
 


### PR DESCRIPTION
Just a nice to have. When tinkering on it it's nice to have to build quickly. Copying the dependency file in first and having it build the dependencies prior to copying in the application code means docker can cache the dependency layer and not run it on every code change.

I would do it for the yarn build too but I'm not positive how that works.